### PR TITLE
Detach threads since we never join them

### DIFF
--- a/pacrunner/src/client.c
+++ b/pacrunner/src/client.c
@@ -84,6 +84,7 @@ static DBusMessage *find_proxy_for_url(DBusConnection *conn,
 					DBusMessage *msg, void *user_data)
 {
 	struct jsrun_data *jsrun;
+	pthread_attr_t attrs;
 
 	jsrun = g_try_new0(struct jsrun_data, 1);
 	if (!jsrun)
@@ -94,7 +95,9 @@ static DBusMessage *find_proxy_for_url(DBusConnection *conn,
 	jsrun->conn = dbus_connection_ref(conn);
 	jsrun->msg = dbus_message_ref(msg);
 
-	if (pthread_create(&jsrun->thread, NULL, jsrun_thread, jsrun) != 0) {
+	pthread_attr_init(&attrs);
+	pthread_attr_setdetachstate(&attrs, PTHREAD_CREATE_DETACHED);
+	if (pthread_create(&jsrun->thread, &attrs, jsrun_thread, jsrun) != 0) {
 		jsrun_free(jsrun);
 		return g_dbus_create_error(msg,
 					PACRUNNER_ERROR_INTERFACE ".Failed",


### PR DESCRIPTION
Plugs this leak:

==14392== HEAP SUMMARY:
==14392==     in use at exit: 99,659 bytes in 3,563 blocks
==14392==   total heap usage: 11,478 allocs, 7,915 frees, 8,096,821 bytes allocated
==14392== 
==14392== 31,104 bytes in 216 blocks are possibly lost in loss record 709 of 709
==14392==    at 0x483643C: calloc (vg_replace_malloc.c:593)
==14392==    by 0x4013B37: _dl_allocate_tls (dl-tls.c:297)
==14392==    by 0x49C0947: pthread_create@@GLIBC_2.4 (allocatestack.c:571)
==14392==    by 0x1418F: find_proxy_for_url (client.c:97)
==14392==    by 0x107CB: process_message (object.c:259)
==14392==    by 0x49F58A3: _dbus_object_tree_dispatch_and_unlock (dbus-object-tree.c:862)
==14392==    by 0x49E5F9B: dbus_connection_dispatch (dbus-connection.c:4672)
==14392==    by 0xD66B: message_dispatch (mainloop.c:72)
==14392==    by 0x48F7A8B: g_idle_dispatch (gmain.c:5251)
==14392==    by 0x48FBB1F: g_main_context_dispatch (gmain.c:3066)
==14392==    by 0x48FBE23: g_main_context_iterate.part.19 (gmain.c:3713)
==14392==    by 0x48FC48B: g_main_loop_run (gmain.c:3906)
==14392== 
==14392== LEAK SUMMARY:
==14392==    definitely lost: 0 bytes in 0 blocks
==14392==    indirectly lost: 0 bytes in 0 blocks
==14392==      possibly lost: 31,104 bytes in 216 blocks
==14392==    still reachable: 68,555 bytes in 3,347 blocks
==14392==         suppressed: 0 bytes in 0 blocks
