### PR TITLE
Each pthread_attr_init should be followed by pthread_attr_destroy

### DIFF
--- a/pacrunner/src/client.c
+++ b/pacrunner/src/client.c
@@ -85,6 +85,7 @@ static DBusMessage *find_proxy_for_url(DBusConnection *conn,
 {
 	struct jsrun_data *jsrun;
 	pthread_attr_t attrs;
+	int err;
 
 	jsrun = g_try_new0(struct jsrun_data, 1);
 	if (!jsrun)
@@ -97,7 +98,9 @@ static DBusMessage *find_proxy_for_url(DBusConnection *conn,
 
 	pthread_attr_init(&attrs);
 	pthread_attr_setdetachstate(&attrs, PTHREAD_CREATE_DETACHED);
-	if (pthread_create(&jsrun->thread, &attrs, jsrun_thread, jsrun) != 0) {
+	err = pthread_create(&jsrun->thread, &attrs, jsrun_thread, jsrun);
+	pthread_attr_destroy(&attrs);
+	if (err != 0) {
 		jsrun_free(jsrun);
 		return g_dbus_create_error(msg,
 					PACRUNNER_ERROR_INTERFACE ".Failed",


### PR DESCRIPTION
If man page says so, let's do it the right way.
